### PR TITLE
usecaseの雛形を生成するコマンドの実装

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,17 @@ const program = createCommand();
 program.command("create-project <projectName>").action((projectName) => {
   new SAO({
     generator: `${__dirname}/packages/create-project`,
-    outDir: `${__dirname}/${projectName}`,
+    outDir: `${projectName}`,
+  }).run();
+});
+
+program.command("usecase <usecaseName>").action((usecaseName) => {
+  new SAO({
+    generator: `${__dirname}/packages/usecase`,
+    outDir: `./`,
+    answers: {
+      usecaseName,
+    },
   }).run();
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,21 @@
         "@types/node": "*"
       }
     },
+    "@types/underscore": {
+      "version": "1.10.23",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.23.tgz",
+      "integrity": "sha512-vX1NPekXhrLquFWskH2thcvFAha187F/lM6xYOoEMZWwJ/6alSk0/ttmGP/YRqcqtCv0TMbZjYAdZyHAEcuU4g==",
+      "dev": true
+    },
+    "@types/underscore.string": {
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@types/underscore.string/-/underscore.string-0.0.38.tgz",
+      "integrity": "sha512-QPMttDInBYkulH/3nON0KnYpEd/RlyE5kUrhuts5d76B/stpjXpDticq+iTluoAsVnVXuGECFhPtuX+aDJdx+A==",
+      "dev": true,
+      "requires": {
+        "@types/underscore": "*"
+      }
+    },
     "@types/validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
@@ -2057,8 +2072,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
       "version": "3.1.0",
@@ -2292,6 +2306,15 @@
       "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
+    "underscore.string": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "requires": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      }
+    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -2382,6 +2405,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   "dependencies": {
     "commander": "^6.1.0",
     "sao": "^2.0.0-beta.1",
+    "underscore.string": "^3.3.5",
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {
     "@types/inquirer": "^7.3.1",
+    "@types/underscore.string": "0.0.38",
     "@types/validate-npm-package-name": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",

--- a/packages/create-project/template/GraphQL/index.ts
+++ b/packages/create-project/template/GraphQL/index.ts
@@ -1,4 +1,6 @@
-import { createServer } from "./lib/infrastructure/graphqlserver/server";
+import { createServer } from "lib/infrastructure/graphqlserver/server";
+import "reflect-metadata";
+import "lib/infrastructure/di";
 
 const main = async () => {
   const server = await createServer();

--- a/packages/create-project/template/GraphQL/lib/infrastructure/graphqlserver/server.ts
+++ b/packages/create-project/template/GraphQL/lib/infrastructure/graphqlserver/server.ts
@@ -1,6 +1,6 @@
 import { ApolloServer } from "apollo-server";
-import { typeDefs } from "../../graphql/typeDefs";
-import { resolvers } from "../../graphql/resolvers";
+import { typeDefs } from "lib/graphql/typeDefs";
+import { resolvers } from "lib/graphql/resolvers";
 
 export const createServer = async (): Promise<ApolloServer> => {
   const server = new ApolloServer({ typeDefs, resolvers });

--- a/packages/create-project/template/REST/index.ts
+++ b/packages/create-project/template/REST/index.ts
@@ -1,4 +1,6 @@
 import { createServer } from "lib/infrastructure/webserver/server";
+import "reflect-metadata";
+import "lib/infrastructure/di";
 
 const main = async () => {
   const server = await createServer();

--- a/packages/create-project/template/REST/index.ts
+++ b/packages/create-project/template/REST/index.ts
@@ -1,4 +1,4 @@
-import { createServer } from "./lib/infrastructure/webserver/server";
+import { createServer } from "lib/infrastructure/webserver/server";
 
 const main = async () => {
   const server = await createServer();

--- a/packages/create-project/template/REST/lib/infrastructure/webserver/server.ts
+++ b/packages/create-project/template/REST/lib/infrastructure/webserver/server.ts
@@ -1,6 +1,6 @@
 import fastify, { FastifyInstance } from "fastify";
 import openapiGlue from "fastify-openapi-glue";
-import esprit from '../../../esprit.config'
+import esprit from "esprit.config";
 
 export const createServer = async (): Promise<FastifyInstance> => {
   const server = fastify({

--- a/packages/create-project/template/gRPC/index.ts
+++ b/packages/create-project/template/gRPC/index.ts
@@ -1,5 +1,5 @@
-import grpc from 'grpc'
-import { createServer } from "./lib/infrastructure/grpcserver/server";
+import grpc from "grpc";
+import { createServer } from "lib/infrastructure/grpcserver/server";
 
 const main = async () => {
   const server = await createServer();

--- a/packages/create-project/template/gRPC/index.ts
+++ b/packages/create-project/template/gRPC/index.ts
@@ -1,5 +1,7 @@
 import grpc from "grpc";
 import { createServer } from "lib/infrastructure/grpcserver/server";
+import "reflect-metadata";
+import "lib/infrastructure/di";
 
 const main = async () => {
   const server = await createServer();

--- a/packages/create-project/template/gRPC/lib/infrastructure/grpcserver/server.ts
+++ b/packages/create-project/template/gRPC/lib/infrastructure/grpcserver/server.ts
@@ -1,4 +1,4 @@
-import grpc from 'grpc'
+import grpc from "grpc";
 
 export const createServer = async (): Promise<grpc.Server> => {
   const server = new grpc.Server()

--- a/packages/create-project/template/static/lib/infrastructure/di.ts
+++ b/packages/create-project/template/static/lib/infrastructure/di.ts
@@ -1,0 +1,7 @@
+import { container } from "tsyringe";
+
+const register = async () => {
+  return;
+};
+
+register();

--- a/packages/create-project/template/static/package.json
+++ b/packages/create-project/template/static/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev index.ts",
+    "dev": "NODE_PATH=./ ts-node-dev index.ts",
     "test": "jest --runInBand --detectOpenHandles"
   },
   "devDependencies": {

--- a/packages/create-project/template/static/tsconfig.json
+++ b/packages/create-project/template/static/tsconfig.json
@@ -59,8 +59,8 @@
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */

--- a/packages/create-project/template/static/tsconfig.json
+++ b/packages/create-project/template/static/tsconfig.json
@@ -42,7 +42,7 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */

--- a/packages/usecase/saofile.ts
+++ b/packages/usecase/saofile.ts
@@ -4,9 +4,20 @@ import { classify } from "underscore.string";
 const generator: GeneratorConfig = {
   actions() {
     const answers: any = this.opts.answers;
-    const usecaseName: string = answers.usecaseName;
-    const classUsecaseName: string = classify(usecaseName);
-    console.log(classUsecaseName);
+    const usecaseNameArray: string[] = answers.usecaseName.split("/");
+    const usecaseName = usecaseNameArray.pop();
+
+    if (!usecaseName) {
+      throw new Error("Required usecase name");
+    }
+
+    const classUsecaseName = classify(usecaseName);
+    const usecasePath = ["lib/application/usecases"]
+      .concat(usecaseNameArray)
+      .join("/");
+    const interactorPath = ["lib/application/interactor"]
+      .concat(usecaseNameArray)
+      .join("/");
 
     return [
       {
@@ -15,13 +26,14 @@ const generator: GeneratorConfig = {
         data: {
           usecaseName,
           classUsecaseName,
+          usecasePath,
         },
       },
       {
         type: "move",
         patterns: {
-          "usecase.ts.template": `lib/application/usecases/${usecaseName}Usecase.ts`,
-          "interactor.ts.template": `lib/application/interactors/${usecaseName}Interactor.ts`,
+          "usecase.ts.template": `${usecasePath}/${usecaseName}Usecase.ts`,
+          "interactor.ts.template": `${interactorPath}/${usecaseName}Interactor.ts`,
         },
       },
     ];

--- a/packages/usecase/saofile.ts
+++ b/packages/usecase/saofile.ts
@@ -38,6 +38,44 @@ const generator: GeneratorConfig = {
           "interactor.spec.ts.template": `spec/${interactorPath}/${usecaseName}Interactor.spec.ts`,
         },
       },
+      {
+        type: "modify",
+        files: "lib/infrastructure/di.ts",
+        handler: (data) => {
+          const toInsertImport = `import { ${classUsecaseName}Interactor } from "lib/${interactorPath}/${usecaseName}Interactor"`;
+          const toInsertRegister = `  container.register("${classUsecaseName}Usecase", { useClass: ${classUsecaseName}Interactor });`;
+          const contentLines: string[] = data.split("\n");
+          const finalImportIndex = findImportsEndpoint(contentLines);
+          const finalRegisterIndex = findRegisterEndpoint(contentLines);
+
+          function findImportsEndpoint(contentLines: string[]): number {
+            const reversedContent = Array.from(contentLines).reverse();
+            const reverseImports = reversedContent.filter((line) =>
+              line.match(/\} from ('|")/)
+            );
+            if (reverseImports.length <= 0) {
+              return 0;
+            }
+            return contentLines.indexOf(reverseImports[0]);
+          }
+
+          function findRegisterEndpoint(contentLines: string[]): number {
+            const reversedContent = Array.from(contentLines).reverse();
+            const reverseRegister = reversedContent.filter((line) =>
+              line.match(/(container.register|register = )/)
+            );
+            if (reverseRegister.length <= 0) {
+              return 0;
+            }
+            return contentLines.indexOf(reverseRegister[0]);
+          }
+
+          contentLines.splice(finalImportIndex + 1, 0, toInsertImport);
+          contentLines.splice(finalRegisterIndex + 2, 0, toInsertRegister);
+
+          return contentLines.join("\n");
+        },
+      },
     ];
   },
 };

--- a/packages/usecase/saofile.ts
+++ b/packages/usecase/saofile.ts
@@ -1,10 +1,12 @@
 import { GeneratorConfig } from "sao";
+import { classify } from "underscore.string";
 
 const generator: GeneratorConfig = {
   actions() {
     const answers: any = this.opts.answers;
     const usecaseName: string = answers.usecaseName;
-    const classUsecaseName: string = usecaseName;
+    const classUsecaseName: string = classify(usecaseName);
+    console.log(classUsecaseName);
 
     return [
       {

--- a/packages/usecase/saofile.ts
+++ b/packages/usecase/saofile.ts
@@ -1,0 +1,29 @@
+import { GeneratorConfig } from "sao";
+
+const generator: GeneratorConfig = {
+  actions() {
+    const answers: any = this.opts.answers;
+    const usecaseName: string = answers.usecaseName;
+    const classUsecaseName: string = usecaseName;
+
+    return [
+      {
+        type: "add",
+        files: "**",
+        data: {
+          usecaseName,
+          classUsecaseName,
+        },
+      },
+      {
+        type: "move",
+        patterns: {
+          "usecase.ts.template": `lib/application/usecases/${usecaseName}Usecase.ts`,
+          "interactor.ts.template": `lib/application/interactors/${usecaseName}Interactor.ts`,
+        },
+      },
+    ];
+  },
+};
+
+module.exports = generator;

--- a/packages/usecase/saofile.ts
+++ b/packages/usecase/saofile.ts
@@ -12,10 +12,10 @@ const generator: GeneratorConfig = {
     }
 
     const classUsecaseName = classify(usecaseName);
-    const usecasePath = ["lib/application/usecases"]
+    const usecasePath = ["application/usecases"]
       .concat(usecaseNameArray)
       .join("/");
-    const interactorPath = ["lib/application/interactor"]
+    const interactorPath = ["application/interactor"]
       .concat(usecaseNameArray)
       .join("/");
 
@@ -27,13 +27,15 @@ const generator: GeneratorConfig = {
           usecaseName,
           classUsecaseName,
           usecasePath,
+          interactorPath,
         },
       },
       {
         type: "move",
         patterns: {
-          "usecase.ts.template": `${usecasePath}/${usecaseName}Usecase.ts`,
-          "interactor.ts.template": `${interactorPath}/${usecaseName}Interactor.ts`,
+          "usecase.ts.template": `lib/${usecasePath}/${usecaseName}Usecase.ts`,
+          "interactor.ts.template": `lib/${interactorPath}/${usecaseName}Interactor.ts`,
+          "interactor.spec.ts.template": `spec/${interactorPath}/${usecaseName}Interactor.spec.ts`,
         },
       },
     ];

--- a/packages/usecase/template/interactor.spec.ts.template
+++ b/packages/usecase/template/interactor.spec.ts.template
@@ -1,0 +1,7 @@
+import { <%= classUsecaseName %>Interactor } from "lib/<%= interactorPath %>/<%= usecaseName %>Interactor";
+
+describe("#handle", () => {
+  xit("add some test", () => {
+    return;
+  });
+});

--- a/packages/usecase/template/interactor.ts.template
+++ b/packages/usecase/template/interactor.ts.template
@@ -4,6 +4,6 @@ import { <%= classUsecaseName %>Usecase } from "../usecases/<%= usecaseName %>Us
 @injectable()
 export class <%= classUsecaseName %>Interactor implements <%= classUsecaseName %>Usecase {
   async handle(): Promise<void> {
-      return;
+    return;
   }
 }

--- a/packages/usecase/template/interactor.ts.template
+++ b/packages/usecase/template/interactor.ts.template
@@ -1,5 +1,5 @@
 import { injectable } from "tsyringe";
-import { <%= classUsecaseName %>Usecase } from "../usecases/<%= usecaseName %>Usecase";
+import { <%= classUsecaseName %>Usecase } from "<%= usecasePath %>/<%= usecaseName %>Usecase";
 
 @injectable()
 export class <%= classUsecaseName %>Interactor implements <%= classUsecaseName %>Usecase {

--- a/packages/usecase/template/interactor.ts.template
+++ b/packages/usecase/template/interactor.ts.template
@@ -1,5 +1,5 @@
 import { injectable } from "tsyringe";
-import { <%= classUsecaseName %>Usecase } from "<%= usecasePath %>/<%= usecaseName %>Usecase";
+import { <%= classUsecaseName %>Usecase } from "lib/<%= usecasePath %>/<%= usecaseName %>Usecase";
 
 @injectable()
 export class <%= classUsecaseName %>Interactor implements <%= classUsecaseName %>Usecase {

--- a/packages/usecase/template/interactor.ts.template
+++ b/packages/usecase/template/interactor.ts.template
@@ -1,0 +1,9 @@
+import { injectable } from "tsyringe";
+import { <%= classUsecaseName %>Usecase } from "../usecases/<%= usecaseName %>Usecase";
+
+@injectable()
+export class <%= classUsecaseName %>Interactor implements <%= classUsecaseName %>Usecase {
+  async handle(): Promise<void> {
+      return;
+  }
+}

--- a/packages/usecase/template/usecase.ts.template
+++ b/packages/usecase/template/usecase.ts.template
@@ -1,0 +1,3 @@
+export interface <%= usecaseName %>Usecase {
+  handle(): Promise<void>;
+}

--- a/packages/usecase/template/usecase.ts.template
+++ b/packages/usecase/template/usecase.ts.template
@@ -1,3 +1,3 @@
-export interface <%= usecaseName %>Usecase {
+export interface <%= classUsecaseName %>Usecase {
   handle(): Promise<void>;
 }


### PR DESCRIPTION
- `node index.ts usecase createUser`という感じで、usecaseのinterfaceとinteractorの雛形を生成

### TODO

- [x] ディレクトリ構造も指定できるようにしたい
  - `usecase user/create/createUser`みたいな？
- [x] specファイルも出力させる
- [x]  class名を大文字に、ファイル名は小文字に
- [x]  DIへの登録もこのコマンドに組み込みたい
- [ ]  ~どの階層から実行しても、プロジェクトルートからファイルを生成するように~
  - NestCliもそのようにはしていなかったので、一旦なし